### PR TITLE
Fix wizard container overflow

### DIFF
--- a/src/pages/Wizard.tsx
+++ b/src/pages/Wizard.tsx
@@ -111,7 +111,7 @@ const Wizard = () => {
       </div>
 
       {/* Main Content */}
-      <main className="flex-1 overflow-y-auto">
+      <main className="flex-1">
         <CurrentStepComponent 
           formData={formData}
           updateFormData={updateFormData}


### PR DESCRIPTION
## Summary
- allow the body element to control scrolling on the wizard page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853d7839138832abe305946495b024f