### PR TITLE
Add animations and 3D tilt to wizard cards

### DIFF
--- a/src/components/wizard/WizardBranding.tsx
+++ b/src/components/wizard/WizardBranding.tsx
@@ -273,11 +273,15 @@ export const WizardBranding = ({ formData, updateFormData, onNext }: WizardBrand
             <RadioGroup value={brandTone} onValueChange={handleBrandToneChange}>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 {brandTones.map((tone) => (
-                  <div key={tone.value} className={`relative p-4 rounded-xl border-2 transition-all cursor-pointer ${
-                    brandTone === tone.value 
-                      ? 'border-primary bg-primary/5 shadow-sm' 
-                      : 'border-gray-200 hover:border-primary/30 hover:bg-primary/5'
-                  }`}>
+                  <div
+                    key={tone.value}
+                    className={`relative p-4 rounded-xl border-2 transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-95 motion-safe:hover:[transform:rotateX(3deg)_rotateY(-3deg)] motion-safe:hover:animate-fade-scale ${
+                      brandTone === tone.value
+                        ? 'border-primary bg-primary/5 shadow-sm'
+                        : 'border-gray-200 hover:border-primary/30 hover:bg-primary/5'
+                    }`}
+                    tabIndex={0}
+                  >
                     <RadioGroupItem value={tone.value} id={tone.value} className="sr-only" />
                     <Label htmlFor={tone.value} className="cursor-pointer block">
                       <div className="flex items-start space-x-3">
@@ -308,11 +312,12 @@ export const WizardBranding = ({ formData, updateFormData, onNext }: WizardBrand
                 <button
                   key={objective}
                   onClick={() => handleObjectiveToggle(objective)}
-                  className={`p-4 rounded-xl border-2 text-left transition-all relative ${
+                  className={`p-4 rounded-xl border-2 text-left transition-all relative focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-95 motion-safe:hover:[transform:rotateX(3deg)_rotateY(-3deg)] motion-safe:hover:animate-fade-scale ${
                     objectives.includes(objective)
                       ? 'border-primary bg-primary/5 shadow-sm'
                       : 'border-gray-200 hover:border-primary/30 hover:bg-primary/5'
                   }`}
+                  tabIndex={0}
                 >
                   <span className="font-medium">{objective}</span>
                   {objectives.includes(objective) && (

--- a/src/components/wizard/WizardMecanique.tsx
+++ b/src/components/wizard/WizardMecanique.tsx
@@ -94,12 +94,13 @@ export const WizardMecanique = ({ formData, updateFormData, onNext, onPrevious }
             return (
               <div
                 key={mechanic.id}
-                className={`relative bg-white rounded-2xl p-6 border-2 cursor-pointer transition-all duration-300 hover:scale-102 hover:shadow-lg ${
+                className={`relative bg-white rounded-2xl p-6 border-2 cursor-pointer transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 active:scale-95 motion-safe:hover:[transform:rotateX(3deg)_rotateY(-3deg)_scale(1.02)] motion-safe:hover:animate-fade-scale ${
                   formData.mechanic === mechanic.id
                     ? 'border-primary shadow-lg shadow-primary/20 ring-4 ring-primary/10'
                     : 'border-gray-200 hover:border-primary/50'
                 }`}
                 onClick={() => handleMechanicSelect(mechanic.id)}
+                tabIndex={0}
               >
                 {/* Badge */}
                 <div className="absolute -top-3 left-4">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -170,20 +170,30 @@ export default {
 						transform: 'translateY(0)'
 					}
 				},
-				'slide-up': {
-					'0%': {
-						opacity: '0',
-						transform: 'translateY(30px)'
-					},
-					'100%': {
-						opacity: '1',
-						transform: 'translateY(0)'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out',
+                                'slide-up': {
+                                        '0%': {
+                                                opacity: '0',
+                                                transform: 'translateY(30px)'
+                                        },
+                                        '100%': {
+                                                opacity: '1',
+                                                transform: 'translateY(0)'
+                                        }
+                                },
+                                'fade-scale': {
+                                        '0%': {
+                                                opacity: '0',
+                                                transform: 'scale(0.95)'
+                                        },
+                                        '100%': {
+                                                opacity: '1',
+                                                transform: 'scale(1)'
+                                        }
+                                }
+                        },
+                        animation: {
+                                'accordion-down': 'accordion-down 0.2s ease-out',
+                                'accordion-up': 'accordion-up 0.2s ease-out',
 				'gradient-shift': 'gradient-shift 8s ease-in-out infinite',
 				'color-shift': 'color-shift 4s ease-in-out infinite',
 				'float': 'float 6s ease-in-out infinite',
@@ -191,9 +201,10 @@ export default {
 				'spin-ultra-slow': 'spin-ultra-slow 20s linear infinite',
 				'glow-pulse': 'glow-pulse 3s ease-in-out infinite',
 				'shimmer': 'shimmer 1.5s ease-in-out',
-				'fade-in': 'fade-in 0.8s ease-out',
-				'slide-up': 'slide-up 0.6s ease-out'
-			},
+                                'fade-in': 'fade-in 0.8s ease-out',
+                                'slide-up': 'slide-up 0.6s ease-out',
+                                'fade-scale': 'fade-scale 0.3s ease-out'
+                        },
 			backdropBlur: {
 				'12': '12px'
 			},


### PR DESCRIPTION
## Summary
- add `fade-scale` animation to Tailwind config
- animate and tilt mechanic cards on hover
- animate branding tone and objective cards on hover

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853e770a194832a8b19382aca6b0e8c