### PR TITLE
Add wheel configurator scaffold

### DIFF
--- a/src/components/configurator/BrandSettingsForm.tsx
+++ b/src/components/configurator/BrandSettingsForm.tsx
@@ -1,0 +1,109 @@
+import { useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Slider } from '@/components/ui/slider';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { WizardFormData } from '@/lib/types';
+
+interface BrandSettingsFormProps {
+  formData: WizardFormData;
+  updateFormData: (data: Partial<WizardFormData>) => void;
+}
+
+export const BrandSettingsForm = ({ formData, updateFormData }: BrandSettingsFormProps) => {
+  const segmentCount = formData.segmentCount || 6;
+
+  useEffect(() => {
+    if (!formData.prizes || formData.prizes.length !== segmentCount) {
+      const prizes = Array.from({ length: segmentCount }, (_, i) => formData.prizes?.[i] || '');
+      updateFormData({ prizes });
+    }
+    if (!formData.segmentColors || formData.segmentColors.length !== segmentCount) {
+      const colors = Array.from({ length: segmentCount }, (_, i) => formData.segmentColors?.[i] || '#e52529');
+      updateFormData({ segmentColors: colors });
+    }
+  }, [segmentCount]);
+
+  const handleFile = (field: 'logo' | 'backgroundDesktop' | 'backgroundMobile') => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    updateFormData({ [field]: file } as Partial<WizardFormData>);
+  };
+
+  const handlePrizeChange = (index: number, value: string) => {
+    const prizes = [...(formData.prizes || [])];
+    prizes[index] = value;
+    updateFormData({ prizes });
+  };
+
+  const handleColorChange = (index: number, value: string) => {
+    const colors = [...(formData.segmentColors || [])];
+    colors[index] = value;
+    updateFormData({ segmentColors: colors });
+  };
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-bold">Brand settings</h2>
+
+      <div className="space-y-2">
+        <Label>Brand name</Label>
+        <Input value={formData.productName || ''} onChange={e => updateFormData({ productName: e.target.value })} />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Brand URL (optional)</Label>
+        <Input value={formData.brandUrl || ''} onChange={e => updateFormData({ brandUrl: e.target.value })} />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Logo</Label>
+        <Input type="file" accept="image/*" onChange={handleFile('logo')} />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Game title</Label>
+        <Input value={formData.gameTitle || ''} onChange={e => updateFormData({ gameTitle: e.target.value })} />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Number of segments: {segmentCount}</Label>
+        <Slider min={2} max={12} step={1} value={[segmentCount]} onValueChange={v => updateFormData({ segmentCount: v[0] })} />
+      </div>
+
+      <div className="space-y-4">
+        {Array.from({ length: segmentCount }).map((_, i) => (
+          <div key={i} className="grid grid-cols-2 gap-2">
+            <div className="flex items-center space-x-2">
+              <Input type="color" value={formData.segmentColors?.[i] || '#e52529'} onChange={e => handleColorChange(i, e.target.value)} className="h-10 w-10 p-0" />
+              <Input value={formData.prizes?.[i] || ''} placeholder={`Prize ${i + 1}`} onChange={e => handlePrizeChange(i, e.target.value)} />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="space-y-2">
+        <Label>Desktop background</Label>
+        <Input type="file" accept="image/*" onChange={handleFile('backgroundDesktop')} />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Mobile background</Label>
+        <Input type="file" accept="image/*" onChange={handleFile('backgroundMobile')} />
+      </div>
+
+      <div className="space-y-2">
+        <Label>Style</Label>
+        <Select value={formData.style || 'Premium'} onValueChange={v => updateFormData({ style: v })}>
+          <SelectTrigger>
+            <SelectValue placeholder="Choose a style" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="Premium">Premium</SelectItem>
+            <SelectItem value="Fun">Fun</SelectItem>
+            <SelectItem value="Minimal">Minimal</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+};

--- a/src/components/configurator/WheelPreview.tsx
+++ b/src/components/configurator/WheelPreview.tsx
@@ -1,0 +1,15 @@
+import { WheelWrapper } from '@/components/wheel/WheelWrapper';
+import type { WizardFormData } from '@/lib/types';
+
+interface WheelPreviewProps {
+  formData: WizardFormData;
+}
+
+export const WheelPreview = ({ formData }: WheelPreviewProps) => (
+  <div className="space-y-4">
+    <h2 className="text-xl font-bold">Wheel of Fortune Preview</h2>
+    <div className="rounded-lg border bg-white p-4">
+      <WheelWrapper formData={formData} />
+    </div>
+  </div>
+);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,10 @@ export interface WizardFormData {
   backgroundMobile?: File | null;
   backgroundDesktopUrl?: string | null;
   backgroundMobileUrl?: string | null;
+  segmentColors?: string[];
+  segmentCount?: number;
+  style?: string;
+  brandUrl?: string;
 }
 
 export interface WizardInput {

--- a/src/pages/Wizard.tsx
+++ b/src/pages/Wizard.tsx
@@ -1,80 +1,40 @@
-
 import { useState } from 'react';
 import { Navigation } from '@/components/Navigation';
 import { Footer } from '@/components/Footer';
-import { BrandConfigurator } from '@/components/wizard/BrandConfigurator';
-import { WizardMecanique } from '@/components/wizard/WizardMecanique';
-import { WizardGeneration } from '@/components/wizard/WizardGeneration';
-import { WizardEditor } from '@/components/wizard/WizardEditor';
+import { BrandSettingsForm } from '@/components/configurator/BrandSettingsForm';
+import { WheelPreview } from '@/components/configurator/WheelPreview';
 import type { WizardFormData } from '@/lib/types';
 
 const Wizard = () => {
-  const [step, setStep] = useState(0);
-
   const [formData, setFormData] = useState<WizardFormData>({
     logo: null,
     primaryColor: '#e52529',
     secondaryColor: '#ffd600',
     accentColor: '#009de0',
     brief: '',
-    mechanic: '',
+    mechanic: 'wheel',
     generatedGame: null,
-    brandTone: '',
-    objectives: [],
-    audience: [],
     productName: '',
     gameTitle: '',
-    prizes: ['', '', '', '']
+    prizes: Array(6).fill(''),
+    segmentColors: Array(6).fill('#e52529'),
+    segmentCount: 6,
+    style: 'Premium',
+    brandUrl: '',
+    backgroundDesktop: null,
+    backgroundMobile: null,
   });
 
-  // Fonction pour mettre à jour les données du formulaire
   const updateFormData = (data: Partial<WizardFormData>) =>
     setFormData(prev => ({ ...prev, ...data }));
-
-  // Passage à l'étape suivante/précédente
-  const next = () => setStep(s => Math.min(s + 1, 3));
-  const previous = () => setStep(s => Math.max(s - 1, 0));
 
   return (
     <div className="min-h-screen bg-gray-light">
       <Navigation />
-
-      {step === 0 && (
-        <BrandConfigurator
-          formData={formData}
-          updateFormData={updateFormData}
-          onNext={next}
-          currentStep={step}
-        />
-      )}
-      {step === 1 && (
-        <WizardMecanique
-          formData={formData}
-          updateFormData={updateFormData}
-          onNext={next}
-          onPrevious={previous}
-          currentStep={step}
-        />
-      )}
-      {step === 2 && (
-        <WizardGeneration
-          formData={formData}
-          updateFormData={updateFormData}
-          onNext={next}
-          onPrevious={previous}
-          currentStep={step}
-        />
-      )}
-      {step === 3 && (
-        <WizardEditor
-          formData={formData}
-          updateFormData={updateFormData}
-          onPrevious={previous}
-          currentStep={step}
-          isLastStep
-        />
-      )}
-
+      <div className="max-w-7xl mx-auto p-4 grid md:grid-cols-2 gap-8">
+        <BrandSettingsForm formData={formData} updateFormData={updateFormData} />
+        <WheelPreview formData={formData} />
+      </div>
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- add dynamic fields for segments, style and brand url to `WizardFormData`
- introduce `BrandSettingsForm` for editing brand settings
- introduce `WheelPreview` to render preview wheel
- rework `/wizard` page to use new form and preview side by side

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68545d573700832ab38d48690bb50d0d